### PR TITLE
Fix serial interface failing on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ A common API for different hardware realizations of a DALI interface.
 * BEGA 71024
 * Serial based SevenLab Hardware
 
+**Note:** Using the serial interface on Windows may have higher latency. This can potentially be
+          improved by tweaking the serial driver config.
+
 ## API
 
 The interface classes implement the following API functions.

--- a/src/dali_interface/serial.py
+++ b/src/dali_interface/serial.py
@@ -54,7 +54,14 @@ class DaliSerial(DaliInterface):
         self.port = serial.Serial(  # pylint: disable=no-member
             port=portname, baudrate=baudrate, timeout=0.2
         )
-        self.port.set_low_latency_mode(True)
+        try:
+            # This only works on Posix systems.
+            self.port.set_low_latency_mode(True)
+        except AttributeError:
+            # Not having low latency mode may result in degraded performance under
+            # Windows. That is still sufficient for some use-cases though and it's
+            # better than no support at all.
+            pass
         self.transparent = transparent
         super().__init__(start_receive=start_receive)
 


### PR DESCRIPTION
Windows doesn't have the low latency mode that Posix systems have. Without any alternatives, we're just ignoring this failing call. This may result in degraded performance under Windows. That is still sufficient for some use-cases and it's better than no support at all.