### PR TITLE
Add representation for the DaliFrame class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A common API for different hardware realizations of a DALI interface.
 * [BEGA 71024](https://www.bega.com/en/products/light-control/dali-usb-interface-71024/)
 * [Serial based SevenLab Hardware](https://github.com/SvenHaedrich/kicad_dali_usb_lpc)
 
-**Note:** Using the serial interface on Windows may have higher latency. This can potentially be
-          improved by tweaking the serial driver config.
+>[!NOTE]
+>Using the serial interface on Windows may exhibit excessive latency. This can potentially be improved by tweaking the serial driver config.
 
 ## API
 

--- a/src/dali_interface/dali_interface.py
+++ b/src/dali_interface/dali_interface.py
@@ -38,6 +38,29 @@ class DaliFrame(NamedTuple):
     status: int = DaliStatus.OK
     message: str = "OK"
 
+    def __repr__(self) -> str:
+        result = f"<{self.__class__.__module__}.{self.__class__.__name__} "
+        for field in DaliFrame._fields:
+            # pylint: disable=no-member
+            if self.__getattribute__(field) != self._field_defaults[field]:
+                # pylint: enable=no-member
+                if field == "data":
+                    if self.length == 8:
+                        result = result + f"data=0x{self.data:02X}, "
+                    elif self.length == 16:
+                        result = result + f"data=0x{self.data:04X}, "
+                    elif self.length == 24:
+                        result = result + f"data=0x{self.data:06X}, "
+                    elif self.length == 32:
+                        result = result + f"data=0x{self.data:08X}, "
+                    else:
+                        result = result + f"data=0x{self.data:X}, "
+                else:
+                    result = result + f"{field}={self.__getattribute__(field)}, "
+        while result[-1:] in (" ", ","):
+            result = result[:-1]
+        return result + ">"
+
 
 @typechecked
 class DaliInterface:

--- a/src/dali_interface/dali_interface.py
+++ b/src/dali_interface/dali_interface.py
@@ -75,7 +75,7 @@ class DaliInterface:
         Args:
             max_queue_size (int, optional): Length of input queue for frames read from DALI bus.
                 Defaults to 40.
-            start_receive (bool, optional): Start a thread that reads DAL frames from the bus
+            start_receive (bool, optional): Start a thread that reads DALI frames from the bus
                 and transfers them into the input queue.
                 Defaults to True.
         """


### PR DESCRIPTION
Display the essential data to support inspection of a `DaliFrame` object.

This PR started out as a copy and paste of a method that might be useful during debugging and turned into a journey of not-so-well-known Python practices. My learnings during this journey makes some of my initial comments on the review appear to be naive.

Here is what  [stackoverflow](https://stackoverflow.com/questions/45153422/how-to-properly-implement-both-str-and-repr) says:

> Neither the official Python documentation nor the [Index of Python Enhancement Proposal](https://www.python.org/dev/peps/) seem to specify clear guidelines on how to override these methods, except for the [3.3 Special method names](https://docs.python.org/3/reference/datamodel.html#object.__repr__) which, among other things, says of `__repr()__`:
> 
> > If at all possible, this should look like a valid Python expression that could be used to recreate an object with the same value [...] This is typically used for debugging, so it is important that the representation is information-rich and unambiguous.
> 
> 
> I like to take inspiration from how `__repr__()` is implemented in some of the standard library modules, take e.g. socket.socket:
> 
> ```
> $ python3
> >>> from socket import socket
> >>> socket()
> <socket.socket fd=3, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('0.0.0.0', 0)>
> So the pattern here is <self.__class__.__module__ + "." + self.__class__.__name__ attribute1=value1, ..., attributeN=valueN>.
> ```
> 
> While `__repr__()` is preferred for debug/testing purposes, the scope of `__str__()` is much more informal and I'd deduce that even looser rules apply. Note that if `__repr__()` is overridden but `__str__()` is not, `__repr__()` calls `__str__()`.