### PR TITLE
Add a specific return for input  lines without DALI frame information

### DIFF
--- a/dali_interface.py
+++ b/dali_interface.py
@@ -25,6 +25,7 @@ class DaliStatus(IntEnum):
     RECOVER = 7
     GENERAL = 8
     UNDEFINED = 9
+    NONE = 10
 
 
 class DaliFrame(NamedTuple):
@@ -35,7 +36,7 @@ class DaliFrame(NamedTuple):
     data: int = 0
     priority: int = 2
     send_twice: bool = False
-    status: int = DaliStatus.OK
+    status: DaliStatus = DaliStatus.OK
     message: str = "OK"
 
 

--- a/serial.py
+++ b/serial.py
@@ -120,6 +120,14 @@ class DaliSerial(DaliInterface):
         try:
             start = line.find("{") + 1
             end = line.find("}")
+            if (end - start) <= 0:
+                return DaliFrame(
+                    timestamp=timestamp,
+                    length=length,
+                    data=data,
+                    status=DaliStatus.NONE,
+                    message="no payload",
+                )
             payload = line[start:end]
             timestamp = int(payload[0:8], 16) / 1000.0
             loopback = payload[8] == ">"


### PR DESCRIPTION
This is useful to gracefully handle cases where the DALI frame information is mixed with other information. For example logging information.