### PR TITLE
Handle input lines without DALI frame

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog for `dali-interface`
 
+## v1.14
+
+- Summarize interface-specific error states into the generic `INTERFACE` status (removes `DaliStatus.GENERAL` and `DaliStatus.UNDEFINED`).
+- Input lines that don't contain valid DALI frame information are ignored for "line"-based devices.
+
 ## v1.13
 
 - Remove run-time typechecking. Instead the package relies on `mypy`'s static analysis.

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,10 @@
 
 ## v1.14
 
-- Summarize interface-specific error states into the generic `INTERFACE` status (removes `DaliStatus.GENERAL` and `DaliStatus.UNDEFINED`).
-- Input lines that don't contain valid DALI frame information are ignored for "line"-based devices.
+- Summarize interface-specific error states into the generic `INTERFACE` status
+  (removes `DaliStatus.GENERAL` and `DaliStatus.UNDEFINED`).
+- Input lines that don't contain valid DALI frame information are ignored for
+  "line"-based devices.
 
 ## v1.13
 

--- a/dali_interface/dali_interface.py
+++ b/dali_interface/dali_interface.py
@@ -37,7 +37,7 @@ class DaliFrame(NamedTuple):
     data: int = 0
     priority: int = 2
     send_twice: bool = False
-    status: int = DaliStatus.OK
+    status: DaliStatus = DaliStatus.OK
     message: str = "OK"
 
     def __repr__(self) -> str:

--- a/dali_interface/dali_interface.py
+++ b/dali_interface/dali_interface.py
@@ -17,16 +17,14 @@ logger = logging.getLogger(__name__)
 class DaliStatus(IntEnum):
     """Status for frames and events."""
 
-    OK = 0
-    LOOPBACK = 1
-    FRAME = 2
-    TIMEOUT = 3
-    TIMING = 4
-    INTERFACE = 5
-    FAILURE = 6
-    RECOVER = 7
-    GENERAL = 8
-    UNDEFINED = 9
+    OK = 0  # interface reports OK, no error condition detected
+    LOOPBACK = 1  # loopback frame - this is a frame that was sent and received back from the interface
+    FRAME = 2  # normal DALI frame
+    TIMEOUT = 3  # timeout occurred
+    TIMING = 4  # timing error within the DALI frame detected
+    INTERFACE = 5  # during operation an error occurred on the interface
+    FAILURE = 6  # failure condition on the DALI bus detected
+    RECOVER = 7  # DALI bus recovered (from failure)
 
 
 class DaliFrame(NamedTuple):
@@ -145,8 +143,6 @@ class DaliInterface:
             rx_frame = self.queue.get(block=True, timeout=timeout)
         except queue.Empty:
             return DaliFrame(status=DaliStatus.TIMEOUT, message="queue is empty, timeout from get")
-        if rx_frame is None:
-            return DaliFrame(status=DaliStatus.GENERAL, message="received None from queue")
         logger.debug(f"return {rx_frame.message} - {rx_frame.length} - {rx_frame.data}")
         return rx_frame
 

--- a/dali_interface/hid.py
+++ b/dali_interface/hid.py
@@ -259,7 +259,7 @@ class DaliUsb(DaliInterface):  # pylint: disable=too-many-instance-attributes
                     elif usb_data[5] == self._USB_STATUS_FRAME_ERROR:
                         status = DaliStatus.TIMING
                     else:
-                        status = DaliStatus.GENERAL
+                        status = DaliStatus.INTERFACE
                 else:
                     return
                 self.queue.put(

--- a/dali_interface/serial.py
+++ b/dali_interface/serial.py
@@ -68,7 +68,7 @@ class DaliSerial(DaliInterface):
     @staticmethod
     def _get_status_and_last_error(  # pylint: disable=too-many-return-statements
         length: int, data: int, loopback: bool
-    ) -> Tuple[int, str]:
+    ) -> Tuple[DaliStatus, str]:
         """Interpret received information."""
         if 0 <= length <= DaliSerial._MAX_BIT_LENGTH:
             if loopback:

--- a/dali_interface/serial.py
+++ b/dali_interface/serial.py
@@ -109,10 +109,10 @@ class DaliSerial(DaliInterface):
             DaliSerial._COMMAND_BAD,
         ):
             return DaliStatus.INTERFACE, "ERROR: INTERFACE"
-        return DaliStatus.UNDEFINED, f"ERROR: CODE 0x{length:02X}"
+        return DaliStatus.INTERFACE, f"ERROR: CODE 0x{length:02X}"
 
     @staticmethod
-    def parse(line: str) -> DaliFrame:
+    def parse(line: str) -> DaliFrame | None:
         """parse a string into a DALI frame
 
         Args:
@@ -120,14 +120,14 @@ class DaliSerial(DaliInterface):
 
         Returns:
             DaliFrame: DALI frame
+            None: if no DALI information found, or if parsing failed
         """
         timestamp: float = 0
         length: int = 0
         data: int = 0
         try:
-            start = line.find("{") + 1
-            end = line.find("}")
-            payload = line[start:end]
+            payload = line.split("{")[1]
+            payload = payload.split("}")[0]
             timestamp = int(payload[0:8], 16) / 1000.0
             loopback = payload[8] == ">"
             length = int(payload[9:11], 16)
@@ -140,14 +140,10 @@ class DaliSerial(DaliInterface):
                 status=status,
                 message=message,
             )
+        except IndexError:
+            return None
         except ValueError:
-            return DaliFrame(
-                timestamp=timestamp,
-                length=length,
-                data=data,
-                status=DaliStatus.GENERAL,
-                message="value error",
-            )
+            return None
 
     def read_data(self) -> None:
         """Read a line from the serial port."""
@@ -156,7 +152,9 @@ class DaliSerial(DaliInterface):
             print(line, end="")
         if len(line) > 0:
             logger.debug(f"received line <{line}> from serial")
-            self.queue.put(self.parse(line))
+            frame = self.parse(line)
+            if frame is not None:
+                self.queue.put(frame)
 
     def _check_loopback(self, frame: DaliFrame) -> None:
         loopback = self.get(DaliInterface.RECEIVE_TIMEOUT)


### PR DESCRIPTION
It is useful to handle cases where the DALI frame information is mixed with other information. For instance Zephyr logs might mix lines with and without DALI frames.